### PR TITLE
Name fixes for one_hot_10 method

### DIFF
--- a/mnist_test.py
+++ b/mnist_test.py
@@ -31,8 +31,8 @@ if __name__ == '__main__':
     net = Network(layers, lr=lr, loss=cross_entropy)
 
     (train_data_X, train_data_Y), v, (tx, ty) = mnist_loader.load_data('./data/mnist.pkl.gz')
-    train_data_Y = one_hot_10(train_data_Y, size=10)
-    ty = one_hot_10(ty, size=10)
+    train_data_Y = one_hot(train_data_Y, size=10)
+    ty = one_hot(ty, size=10)
     train_data_X = np.reshape(train_data_X, [-1, 28, 28, 1])
     tx = np.reshape(tx, [-1, 28, 28, 1])
     for epoch in xrange(100000):


### PR DESCRIPTION
Original file gave run-time error for undefined method name one_hot_10.